### PR TITLE
Added --include-pdf to extract text from PDF files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # pip3 install -r requirements.txt 
+pypdf==4.0.1
 rich==13.3.1
 Scrapy==2.8.0
 tld==0.12.7

--- a/src/cewler/cewler.py
+++ b/src/cewler/cewler.py
@@ -49,6 +49,7 @@ class Cewler:
         parser.add_argument("-d", "--depth", type=int, default=2, help="directory path depth to crawl, 0 for unlimited (default: 2)")
         parser.add_argument("-css", "--include-css", action="store_true", help="include CSS from external files and <style> tags")
         parser.add_argument("-js", "--include-js", action="store_true", help="include JavaScript from external files and <script> tags")
+        parser.add_argument("-pdf", "--include-pdf", action="store_true", help="include text from PDF files")
         parser.add_argument("-l", "--lowercase", action="store_true", help="lowercase all parsed words")
         parser.add_argument("-m", "--min-word-length", type=int, default=5, help="minimum word length to include (default: 5)")
         parser.add_argument("-o", "--output", help="file were to stream and store wordlist instead of screen (default: screen)")
@@ -233,8 +234,8 @@ class Cewler:
 
             with self.live:
                 process = CrawlerProcess(self.get_scrapy_settings_and_init_logging(args.user_agent, args.depth, args.rate, args.subdomain_strategy))
-                process.crawl(spider.CewlerSpider, console=self.console, url=args.url, file_words=args.output, file_emails=args.output_emails, file_urls=args.output_urls, include_js=args.include_js, include_css=args.include_css, should_lowercase=args.lowercase,
-                              without_numbers=args.without_numbers, min_word_length=args.min_word_length, verbose=args.verbose, stream_to_file=args.stream, spider_event_callback=self.on_spider_event)
+                process.crawl(spider.CewlerSpider, console=self.console, url=args.url, file_words=args.output, file_emails=args.output_emails, file_urls=args.output_urls, include_js=args.include_js, include_css=args.include_css, include_pdf=args.include_pdf,
+                              should_lowercase=args.lowercase, without_numbers=args.without_numbers, min_word_length=args.min_word_length, verbose=args.verbose, stream_to_file=args.stream, spider_event_callback=self.on_spider_event)
                 process.start()
             print("")
 


### PR DESCRIPTION
Hello, I added support for extracting text from PDF files when crawling websites. I did some small refactoring to fit in the code.

I chose the pypdf library mainly because it's written in pure Python, which means no third-party dependencies. It is also actively developed. Another library which I considered was pdfminer.six, but pypdf has faster text extraction according to: https://github.com/py-pdf/benchmarks

I tested this multiple websites with PDFs without any problems.