### PR TITLE
Add missing dependency to pyproject file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ keywords = ["custom wordlist", "wordlist generator", "bug bounty hunting", "secu
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
+    "pypdf==4.0.1",
     "rich==13.3.1",
     "Scrapy==2.8.0",
     "tld==0.12.7",
-    "Twisted==22.10.0"
+    "Twisted==22.10.0",
+    "constants==2023.2.0"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,7 @@ dependencies = [
     "rich==13.3.1",
     "Scrapy==2.8.0",
     "tld==0.12.7",
-    "Twisted==22.10.0",
-    "constants==2023.2.0"
+    "Twisted==22.10.0"
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ rich==13.3.1
 Scrapy==2.8.0
 tld==0.12.7
 Twisted==22.10.0
-constants==2023.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ rich==13.3.1
 Scrapy==2.8.0
 tld==0.12.7
 Twisted==22.10.0
+constants==2023.2.0


### PR DESCRIPTION
Hi,

You forgot the `pypdf` dependency in the `pyproject.toml` file during your last release (v1.2.0).

**Fail :**

```bash
[Apr 04, 2024 - 11:49:22 (CEST)] exegol-ctf4 /workspace # pipx install --system-site-packages git+https://github.com/roys/cewler
  installed package cewler 1.2.0, installed using Python 3.11.8
  These apps are now globally available
    - cewler
done! ✨ 🌟 ✨
```

```bash
[Apr 04, 2024 - 11:49:44 (CEST)] exegol-ctf4 /workspace # cewler
Traceback (most recent call last):
  File "/root/.local/share/pipx/venvs/cewler/lib/python3.11/site-packages/cewler/cewler.py", line 20, in <module>
    from . import spider
  File "/root/.local/share/pipx/venvs/cewler/lib/python3.11/site-packages/cewler/spider.py", line 13, in <module>
    from pypdf import PdfReader
ModuleNotFoundError: No module named 'pypdf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/bin/cewler", line 5, in <module>
    from cewler.cewler import main
  File "/root/.local/share/pipx/venvs/cewler/lib/python3.11/site-packages/cewler/cewler.py", line 24, in <module>
    import constants
ModuleNotFoundError: No module named 'constants'
```

**Works :**

```bash
[Apr 04, 2024 - 11:47:42 (CEST)] exegol-ctf4 /workspace # pipx install --system-site-packages git+https://github.com/QU35T-code/cewler@fix/pytoml
  installed package cewler 1.2.0, installed using Python 3.11.8
  These apps are now globally available
    - cewler
done! ✨ 🌟 ✨
```

```bash
[Apr 04, 2024 - 11:48:24 (CEST)] exegol-ctf4 /workspace # cewler
usage: cewler [-h] [-d DEPTH] [-css] [-js] [-pdf] [-l] [-m MIN_WORD_LENGTH] [-o OUTPUT] [-oe OUTPUT_EMAILS] [-ou OUTPUT_URLS] [-r RATE] [-s {all,children,exact}]
              [--stream] [-u USER_AGENT] [-v] [-w]
              url

CeWLeR v.1.2.0 - Custom Word List generator Redefined
```

_Catched by the Exegol pipeline_